### PR TITLE
Allow custom include and library link path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,11 @@
 extern crate bindgen;
 extern crate cc;
 
-use std::path::Path;
-use std::path::PathBuf;
 use std::{
     env::{self, VarError},
     ffi::OsStr,
     iter,
+    path::PathBuf,
 };
 
 fn main() {
@@ -65,13 +64,13 @@ fn main() {
 
     {
         let mut build = cc::Build::new();
-        build.file("src/wrapper.c").out_dir(&Path::new("target/"));
+        build.file("src/wrapper.c");
 
         for include_path in include_paths.iter() {
             build.include(include_path);
         }
 
-        build.compile("sfcgalwrapper.a");
+        build.compile("sfcgalwrapper");
     }
 
     let bindings = bindgen::Builder::default()

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,87 @@
 extern crate bindgen;
 extern crate cc;
 
-use std::env;
 use std::path::Path;
 use std::path::PathBuf;
+use std::{
+    env::{self, VarError},
+    ffi::OsStr,
+    iter,
+};
 
 fn main() {
     println!("cargo:rustc-link-lib=SFCGAL");
 
-    cc::Build::new()
-        .file("src/wrapper.c")
-        .include("/usr/include")
-        .out_dir(&Path::new("target/"))
-        .compile("sfcgalwrapper.a");
+    let mut cargo_metadata = Vec::with_capacity(64);
+    let link_libs_opt = env_var("SFCGAL_LINK_LIBS");
+    let link_paths_opt = env_var("SFCGAL_LINK_PATHS");
+    let include_paths_opt = env_var("SFCGAL_INCLUDE_PATHS");
+
+    if let Some(link_paths) = link_paths_opt {
+        let meta = link_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|x| !x.is_empty())
+            .map(|path| {
+                let out = iter::once(format!("cargo:rustc-link-search={}", path));
+                #[cfg(target_os = "macos")]
+                {
+                    out.chain(iter::once(format!(
+                        "cargo:rustc-link-search=framework={}",
+                        path
+                    )))
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    out
+                }
+            })
+            .flatten();
+
+        cargo_metadata.extend(meta);
+    }
+
+    if let Some(link_libs) = link_libs_opt {
+        cargo_metadata.extend(
+            process_library_list(
+                link_libs
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|x| !x.is_empty()),
+            )
+            .map(|l| format!("cargo:rustc-link-lib={}", l)),
+        );
+    }
+
+    let include_paths: Vec<_> = match include_paths_opt {
+        Some(include_paths) => include_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|x| !x.is_empty())
+            .map(PathBuf::from)
+            .collect(),
+        None => vec![PathBuf::from("/usr/include")],
+    };
+
+    {
+        let mut build = cc::Build::new();
+        build.file("src/wrapper.c").out_dir(&Path::new("target/"));
+
+        for include_path in include_paths.iter() {
+            build.include(include_path);
+        }
+
+        build.compile("sfcgalwrapper.a");
+    }
 
     let bindings = bindgen::Builder::default()
         .rust_target(bindgen::RustTarget::Stable_1_33)
         .header("src/wrapper.h")
+        .clang_args(
+            include_paths
+                .iter()
+                .map(|path| format!("-I{}", path.display())),
+        )
         .whitelist_type("sfcgal_.*$")
         .whitelist_var("sfcgal_.*$")
         .whitelist_function("sfcgal_.*$")
@@ -30,4 +95,41 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    for meta in cargo_metadata.into_iter() {
+        println!("{}", meta);
+    }
+}
+
+fn process_library_list(
+    libs: impl IntoIterator<Item = impl Into<PathBuf>>,
+) -> impl Iterator<Item = String> {
+    libs.into_iter().map(|x| {
+        let mut path: PathBuf = x.into();
+        let extension = path.extension().and_then(OsStr::to_str).unwrap_or_default();
+        let is_framework = extension.eq_ignore_ascii_case("framework");
+        const LIB_EXTS: [&str; 7] = ["so", "a", "dll", "lib", "dylib", "framework", "tbd"];
+        if is_framework || LIB_EXTS.iter().any(|e| e.eq_ignore_ascii_case(extension)) {
+            path.set_extension("");
+        }
+        path.file_name()
+            .and_then(|f| {
+                f.to_str().map(|f| {
+                    if is_framework {
+                        format!("framework={}", f)
+                    } else {
+                        f.to_owned()
+                    }
+                })
+            })
+            .expect("Invalid library name")
+    })
+}
+
+fn env_var<K: AsRef<OsStr>>(key: K) -> Option<String> {
+    match env::var(key) {
+        Ok(val) => Some(val),
+        Err(VarError::NotPresent) => None,
+        Err(VarError::NotUnicode(_)) => panic!("the value of environment variable is not Unicode"),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub fn initialize() {
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
     INIT.call_once(|| unsafe {
         sfcgal_init();
         w_sfcgal_init_handlers();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,4 @@ mod tests {
             String::from("WKT parse error, Coordinate dimension < 2 (, 1)"),
         );
     }
-
 }


### PR DESCRIPTION
This patch pulls several snippets from [opencv-rust](https://github.com/twistedfall/opencv-rust). Now these env vars are added to configure custom search paths.

- `SFCGAL_INCLUDE_PATHS`: comma-separated paths to header dirs
- `SFCGAL_LINK_PATHS`: comma-separated paths to library search dirs
- `SFCGAL_LINK_LIBS`: comma-separated paths to library files

It is tested on Ubuntu 18.04 with sfcgal 1.3.7 using custom path and on ArchLinux using system default path.