### PR TITLE
Update bindgen and cc dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/mthh/sfcgal-sys"
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "0.47.3"
-cc = "~1.0"
+bindgen = "0.54"
+cc = "1.0"


### PR DESCRIPTION
- Update bindgen to 0.54
- Use version `1.0` instead of `~1.0` to follow the semver convension